### PR TITLE
feat: optimize Windows build and installation process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,9 +179,14 @@ endif
 # SEC-22: Set TYPST_SHA256 to verify integrity of downloaded binary
 ifeq ($(OS),Windows_NT)
 _download-typst:
-	@powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path (Split-Path -Parent '$(TYPST_OUT)') | Out-Null"
-	@powershell -NoProfile -Command '$$out = "$(TYPST_OUT)"; $$cache = "$(TYPST_CACHE_DIR)/$(TYPST_ARCHIVE)"; New-Item -ItemType Directory -Force -Path (Split-Path -Parent $$cache) | Out-Null; if (Test-Path $$out) { $$sig = -join ([System.IO.File]::ReadAllBytes($$out)[0..1] | ForEach-Object { [char]$$_ }); if ($$sig -ne "MZ") { if ("$(TYPST_ARCHIVE)" -like "*.zip" -and $$sig -eq "PK" -and -not (Test-Path $$cache)) { Move-Item -LiteralPath $$out -Destination $$cache -Force; Write-Host "==> Recovered cached typst archive $$cache" } else { Remove-Item -LiteralPath $$out -Force } } }'
-	@powershell -NoProfile -Command 'if (-not (Test-Path "$(TYPST_OUT)")) { if ("$(REQUIRE_TYPST_SHA256)" -eq "1" -and "$(TYPST_SHA256)" -eq "") { throw "ERROR: TYPST_SHA256 is required" }; $$cache = "$(TYPST_CACHE_DIR)/$(TYPST_ARCHIVE)"; New-Item -ItemType Directory -Force -Path (Split-Path -Parent $$cache) | Out-Null; if (-not (Test-Path $$cache)) { Write-Host "==> Downloading typst $(TYPST_VERSION) ($(TYPST_ARCHIVE))..."; & curl.exe -fL --retry 5 --retry-delay 2 --connect-timeout 30 --max-time 600 "$(TYPST_BASE)/$(TYPST_ARCHIVE)" -o $$cache; if ($$LASTEXITCODE -ne 0) { Remove-Item -LiteralPath $$cache -Force -ErrorAction SilentlyContinue; exit $$LASTEXITCODE } } else { Write-Host "==> Using cached typst archive $$cache" }; if ("$(TYPST_SHA256)" -ne "") { $$hash = (Get-FileHash -Algorithm SHA256 $$cache).Hash.ToLowerInvariant(); if ($$hash -ne "$(TYPST_SHA256)") { Remove-Item -LiteralPath $$cache -Force -ErrorAction SilentlyContinue; throw "ERROR: typst checksum verification failed!" } }; $$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()); New-Item -ItemType Directory -Path $$tmp | Out-Null; try { if ("$(TYPST_ARCHIVE)" -like "*.zip") { Expand-Archive -LiteralPath $$cache -DestinationPath $$tmp -Force } else { & "$$env:SystemRoot\System32\tar.exe" -xf $$cache -C $$tmp; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } }; $$bin = Get-ChildItem -LiteralPath $$tmp -Recurse -File | Where-Object { $$_.Name -eq "typst.exe" -or $$_.Name -eq "typst" } | Sort-Object @{Expression = { if ($$_.Name -eq "typst.exe") { 0 } else { 1 } }}, @{Expression = "Length"; Descending = $$true} | Select-Object -First 1; if (-not $$bin) { throw "typst binary not found in archive" }; Copy-Item -LiteralPath $$bin.FullName -Destination "$(TYPST_OUT)" -Force; $$outSig = -join ([System.IO.File]::ReadAllBytes("$(TYPST_OUT)")[0..1] | ForEach-Object { [char]$$_ }); if ("$(TYPST_OUT)" -like "*.exe" -and $$outSig -ne "MZ") { Remove-Item -LiteralPath "$(TYPST_OUT)" -Force; throw "extracted typst is not a Windows executable" }; Write-Host "==> $(TYPST_OUT)" } finally { Remove-Item -LiteralPath $$tmp -Recurse -Force -ErrorAction SilentlyContinue } }'
+	@pwsh.exe -NoProfile -ExecutionPolicy Bypass -File build/windows/download-typst.ps1 \
+		-TypestOut "$(TYPST_OUT)" \
+		-CacheDir "$(TYPST_CACHE_DIR)" \
+		-Archive "$(TYPST_ARCHIVE)" \
+		-BaseUrl "$(TYPST_BASE)" \
+		-Sha256 "$(TYPST_SHA256)" \
+		-RequireSha256 "$(REQUIRE_TYPST_SHA256)" \
+		-Version "$(TYPST_VERSION)"
 else
 _download-typst:
 	@mkdir -p $(dir $(TYPST_OUT))
@@ -219,8 +224,13 @@ endif
 # Usage: $(MAKE) _download-tinymist TINYMIST_ARCHIVE=<name> TINYMIST_OUT=<path> TINYMIST_SHA256=<hash>
 ifeq ($(OS),Windows_NT)
 _download-tinymist:
-	@powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path (Split-Path -Parent '$(TINYMIST_OUT)') | Out-Null"
-	@powershell -NoProfile -Command 'if (-not (Test-Path "$(TINYMIST_OUT)")) { if ("$(TINYMIST_SHA256)" -eq "") { throw "ERROR: TINYMIST_SHA256 is required" }; $$cache = "$(TINYMIST_CACHE_DIR)/$(TINYMIST_ARCHIVE)"; New-Item -ItemType Directory -Force -Path (Split-Path -Parent $$cache) | Out-Null; if (-not (Test-Path $$cache)) { Write-Host "==> Downloading tinymist $(TINYMIST_VERSION) ($(TINYMIST_ARCHIVE))..."; & curl.exe -fL --retry 5 --retry-delay 2 --connect-timeout 30 --max-time 600 "$(TINYMIST_BASE)/$(TINYMIST_ARCHIVE)" -o $$cache; if ($$LASTEXITCODE -ne 0) { Remove-Item -LiteralPath $$cache -Force -ErrorAction SilentlyContinue; exit $$LASTEXITCODE } } else { Write-Host "==> Using cached tinymist archive $$cache" }; $$hash = (Get-FileHash -Algorithm SHA256 $$cache).Hash.ToLowerInvariant(); if ($$hash -ne "$(TINYMIST_SHA256)") { Remove-Item -LiteralPath $$cache -Force -ErrorAction SilentlyContinue; throw "ERROR: tinymist checksum verification failed!" }; $$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName()); New-Item -ItemType Directory -Path $$tmp | Out-Null; try { if ("$(TINYMIST_ARCHIVE)" -like "*.zip") { Expand-Archive -LiteralPath $$cache -DestinationPath $$tmp -Force } else { & "$$env:SystemRoot\System32\tar.exe" -xf $$cache -C $$tmp; if ($$LASTEXITCODE -ne 0) { exit $$LASTEXITCODE } }; $$bin = Get-ChildItem -LiteralPath $$tmp -Recurse -File | Where-Object { $$_.Name -eq "tinymist.exe" -or $$_.Name -eq "tinymist" } | Sort-Object @{Expression = { if ($$_.Name -eq "tinymist.exe") { 0 } else { 1 } }}, @{Expression = "Length"; Descending = $$true} | Select-Object -First 1; if (-not $$bin) { throw "tinymist binary not found in archive" }; Copy-Item -LiteralPath $$bin.FullName -Destination "$(TINYMIST_OUT)" -Force; $$outSig = -join ([System.IO.File]::ReadAllBytes("$(TINYMIST_OUT)")[0..1] | ForEach-Object { [char]$$_ }); if ("$(TINYMIST_OUT)" -like "*.exe" -and $$outSig -ne "MZ") { Remove-Item -LiteralPath "$(TINYMIST_OUT)" -Force; throw "extracted tinymist is not a Windows executable" }; Write-Host "==> $(TINYMIST_OUT)" } finally { Remove-Item -LiteralPath $$tmp -Recurse -Force -ErrorAction SilentlyContinue } }'
+	@pwsh.exe -NoProfile -ExecutionPolicy Bypass -File build/windows/download-tinymist.ps1 \
+		-TinymistOut "$(TINYMIST_OUT)" \
+		-CacheDir "$(TINYMIST_CACHE_DIR)" \
+		-Archive "$(TINYMIST_ARCHIVE)" \
+		-BaseUrl "$(TINYMIST_BASE)" \
+		-Sha256 "$(TINYMIST_SHA256)" \
+		-Version "$(TINYMIST_VERSION)"
 else
 _download-tinymist:
 	@mkdir -p $(dir $(TINYMIST_OUT))
@@ -678,9 +688,11 @@ windows-installer: inno
 .PHONY: _inno-language
 ifeq ($(OS),Windows_NT)
 _inno-language:
-	@powershell -NoProfile -Command "New-Item -ItemType Directory -Force -Path '$(INNO_LANG_DIR)' | Out-Null"
-	@powershell -NoProfile -Command 'if (-not (Test-Path "$(INNO_ZH_FILE)")) { Write-Host "==> Downloading Inno Setup Simplified Chinese language file..."; Invoke-WebRequest -UseBasicParsing -Uri "$(INNO_ZH_URL)" -OutFile "$(INNO_ZH_FILE).tmp"; $$hash = (Get-FileHash -Algorithm SHA256 "$(INNO_ZH_FILE).tmp").Hash.ToLowerInvariant(); if ($$hash -ne "$(INNO_ZH_SHA256)") { Remove-Item -Force "$(INNO_ZH_FILE).tmp" -ErrorAction SilentlyContinue; throw "ERROR: checksum mismatch for $(INNO_ZH_FILE)" }; Move-Item -LiteralPath "$(INNO_ZH_FILE).tmp" -Destination "$(INNO_ZH_FILE)" -Force }'
-	@powershell -NoProfile -Command '$$hash = (Get-FileHash -Algorithm SHA256 "$(INNO_ZH_FILE)").Hash.ToLowerInvariant(); if ($$hash -ne "$(INNO_ZH_SHA256)") { throw "ERROR: checksum mismatch for $(INNO_ZH_FILE)" }'
+	@pwsh.exe -NoProfile -ExecutionPolicy Bypass -File build/windows/download-inno-lang.ps1 \
+		-LangDir "$(INNO_LANG_DIR)" \
+		-ZhFile "$(INNO_ZH_FILE)" \
+		-ZhUrl "$(INNO_ZH_URL)" \
+		-ZhSha256 "$(INNO_ZH_SHA256)"
 else
 _inno-language:
 	@mkdir -p "$(INNO_LANG_DIR)"

--- a/build/windows/download-inno-lang.ps1
+++ b/build/windows/download-inno-lang.ps1
@@ -1,0 +1,31 @@
+param(
+    [string]$LangDir,
+    [string]$ZhFile,
+    [string]$ZhUrl,
+    [string]$ZhSha256
+)
+
+# Create language directory
+New-Item -ItemType Directory -Force -Path $LangDir | Out-Null
+
+# Download if needed
+if (-not (Test-Path $ZhFile)) {
+    Write-Host "==> Downloading Inno Setup Simplified Chinese language file..."
+    Invoke-WebRequest -UseBasicParsing -Uri $ZhUrl -OutFile "$ZhFile.tmp"
+
+    $hash = (Get-FileHash -Algorithm SHA256 "$ZhFile.tmp").Hash.ToLowerInvariant()
+    if ($hash -ne $ZhSha256) {
+        Remove-Item -Force "$ZhFile.tmp" -ErrorAction SilentlyContinue
+        throw "ERROR: checksum mismatch for $ZhFile"
+    }
+
+    Move-Item -LiteralPath "$ZhFile.tmp" -Destination $ZhFile -Force
+}
+
+# Verify existing file
+$hash = (Get-FileHash -Algorithm SHA256 $ZhFile).Hash.ToLowerInvariant()
+if ($hash -ne $ZhSha256) {
+    throw "ERROR: checksum mismatch for $ZhFile"
+}
+
+Write-Host "==> Language file verified: $ZhFile"

--- a/build/windows/download-tinymist.ps1
+++ b/build/windows/download-tinymist.ps1
@@ -1,0 +1,75 @@
+param(
+    [string]$TinymistOut,
+    [string]$CacheDir,
+    [string]$Archive,
+    [string]$BaseUrl,
+    [string]$Sha256,
+    [string]$Version
+)
+
+# Create output directory
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $TinymistOut) | Out-Null
+
+# Download if needed
+if (-not (Test-Path $TinymistOut)) {
+    if ($Sha256 -eq "") {
+     throw "ERROR: TINYMIST_SHA256 is required"
+    }
+
+    $cache = Join-Path $CacheDir $Archive
+    New-Item -ItemType Directory -Force -Path (Split-Path -Parent $cache) | Out-Null
+
+    if (-not (Test-Path $cache)) {
+        Write-Host "==> Downloading tinymist $Version ($Archive)..."
+        & curl.exe -fL --retry 5 --retry-delay 2 --connect-timeout 30 --max-time 600 "$BaseUrl/$Archive" -o $cache
+        if ($LASTEXITCODE -ne 0) {
+            Remove-Item -LiteralPath $cache -Force -ErrorAction SilentlyContinue
+            exit $LASTEXITCODE
+        }
+    } else {
+        Write-Host "==> Using cached tinymist archive $cache"
+    }
+
+    # Verify checksum
+    $hash = (Get-FileHash -Algorithm SHA256 $cache).Hash.ToLowerInvariant()
+    if ($hash -ne $Sha256) {
+        Remove-Item -LiteralPath $cache -Force -ErrorAction SilentlyContinue
+        throw "ERROR: tinymist checksum verification failed!"
+    }
+
+    # Extract
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmp | Out-Null
+
+    try {
+        if ($Archive -like "*.zip") {
+            Expand-Archive -LiteralPath $cache -DestinationPath $tmp -Force
+        } else {
+          & "$env:SystemRoot\System32\tar.exe" -xf $cache -C $tmp
+            if ($LASTEXITCODE -ne 0) {
+           exit $LASTEXITCODE
+          }
+        }
+
+        $bin = Get-ChildItem -LiteralPath $tmp -Recurse -File |
+          Where-Object { $_.Name -eq "tinymist.exe" -or $_.Name -eq "tinymist" } |
+         Sort-Object @{Expression = { if ($_.Name -eq "tinymist.exe") { 0 } else { 1 } }}, @{Expression = "Length"; Descending = $true} |
+         Select-Object -First 1
+
+        if (-not $bin) {
+            throw "tinymist binary not found in archive"
+        }
+
+      Copy-Item -LiteralPath $bin.FullName -Destination $TinymistOut -Force
+
+        $outSig = -join ([System.IO.File]::ReadAllBytes($TinymistOut)[0..1] | ForEach-Object { [char]$_ })
+        if ($TinymistOut -like "*.exe" -and $outSig -ne "MZ") {
+            Remove-Item -LiteralPath $TinymistOut -Force
+            throw "extracted tinymist is not a Windows executable"
+        }
+
+        Write-Host "==> $TinymistOut"
+    } finally {
+      Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/build/windows/download-typst.ps1
+++ b/build/windows/download-typst.ps1
@@ -1,0 +1,91 @@
+param(
+    [string]$TypestOut,
+    [string]$CacheDir,
+    [string]$Archive,
+    [string]$BaseUrl,
+    [string]$Sha256,
+    [string]$RequireSha256,
+    [string]$Version
+)
+
+# Create output directory
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $TypestOut) | Out-Null
+
+# Recovery logic: check if output exists and is valid
+$cache = Join-Path $CacheDir $Archive
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $cache) | Out-Null
+
+if (Test-Path $TypestOut) {
+    $sig = -join ([System.IO.File]::ReadAllBytes($TypestOut)[0..1] | ForEach-Object { [char]$_ })
+    if ($sig -ne "MZ") {
+        if ($Archive -like "*.zip" -and $sig -eq "PK" -and -not (Test-Path $cache)) {
+            Move-Item -LiteralPath $TypestOut -Destination $cache -Force
+      Write-Host "==> Recovered cached typst archive $cache"
+        } else {
+            Remove-Item -LiteralPath $TypestOut -Force
+        }
+    }
+}
+
+# Download if needed
+if (-not (Test-Path $TypestOut)) {
+    if ($RequireSha256 -eq "1" -and $Sha256 -eq "") {
+        throw "ERROR: TYPST_SHA256 is required"
+    }
+
+    if (-not (Test-Path $cache)) {
+        Write-Host "==> Downloading typst $Version ($Archive)..."
+        & curl.exe -fL --retry 5 --retry-delay 2 --connect-timeout 30 --max-time 600 "$BaseUrl/$Archive" -o $cache
+      if ($LASTEXITCODE -ne 0) {
+            Remove-Item -LiteralPath $cache -Force -ErrorAction SilentlyContinue
+            exit $LASTEXITCODE
+        }
+  } else {
+     Write-Host "==> Using cached typst archive $cache"
+    }
+
+    # Verify checksum
+    if ($Sha256 -ne "") {
+        $hash = (Get-FileHash -Algorithm SHA256 $cache).Hash.ToLowerInvariant()
+        if ($hash -ne $Sha256) {
+         Remove-Item -LiteralPath $cache -Force -ErrorAction SilentlyContinue
+            throw "ERROR: typst checksum verification failed!"
+        }
+    }
+
+    # Extract
+    $tmp = Join-Path ([System.IO.Path]::GetTempPath()) ([System.IO.Path]::GetRandomFileName())
+    New-Item -ItemType Directory -Path $tmp | Out-Null
+
+    try {
+        if ($Archive -like "*.zip") {
+        Expand-Archive -LiteralPath $cache -DestinationPath $tmp -Force
+        } else {
+          & "$env:SystemRoot\System32\tar.exe" -xf $cache -C $tmp
+            if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+            }
+        }
+
+        $bin = Get-ChildItem -LiteralPath $tmp -Recurse -File |
+            Where-Object { $_.Name -eq "typst.exe" -or $_.Name -eq "typst" } |
+               Sort-Object @{Expression = { if ($_.Name -eq "typst.exe") { 0 } else { 1 } }}, @{Expression = "Length"; Descending = $true} |
+               Select-Object -First 1
+
+        if (-not $bin) {
+            throw "typst binary not found in archive"
+        }
+
+        Copy-Item -LiteralPath $bin.FullName -Destination $TypestOut -Force
+
+        $outSig = -join ([System.IO.File]::ReadAllBytes($TypestOut)[0..1] | ForEach-Object { [char]$_ })
+        if ($TypestOut -like "*.exe" -and $outSig -ne "MZ") {
+            Remove-Item -LiteralPath $TypestOut -Force
+          throw "extracted typst is not a Windows executable"
+        }
+
+        Write-Host "==> $TypestOut"
+    } finally {
+        Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/build/windows/installer/presto.iss
+++ b/build/windows/installer/presto.iss
@@ -68,6 +68,7 @@ AppCopyright={#INFO_COPYRIGHT}
 AppMutex=com.mrered.presto
 DefaultDirName={autopf}\{#INFO_COMPANYNAME}\{#INFO_PRODUCTNAME}
 DefaultGroupName={#INFO_PRODUCTNAME}
+UsedUserAreasWarning=no
 DisableProgramGroupPage=yes
 OutputDir={#ARG_OUTPUT_DIR}
 OutputBaseFilename={#ARG_OUTPUT_BASENAME}
@@ -77,7 +78,8 @@ LicenseFile={#SourcePath}\license.txt
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
-PrivilegesRequired=admin
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=dialog
 MinVersion=10.0
 ArchitecturesAllowed={#ARCHITECTURES_ALLOWED}
 ArchitecturesInstallIn64BitMode={#ARCHITECTURES_64BIT}
@@ -118,7 +120,7 @@ Name: "{group}\Presto"; Filename: "{app}\{#PRODUCT_EXECUTABLE}"; WorkingDir: "{a
 Name: "{group}\卸载 Presto"; Filename: "{uninstallexe}"; Tasks: startmenuicon
 
 [Run]
-Filename: "{tmp}\vc_redist.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "{cm:InstallingVCRuntime}"; Flags: runhidden waituntilterminated
+Filename: "{tmp}\vc_redist.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "{cm:InstallingVCRuntime}"; Flags: runhidden waituntilterminated; Check: NeedsVCRedist
 Filename: "{app}\{#PRODUCT_EXECUTABLE}"; Parameters: "--migrate-legacy-data"; StatusMsg: "Migrating existing Presto data..."; Flags: runhidden waituntilterminated
 Filename: "{app}\{#PRODUCT_EXECUTABLE}"; Description: "{cm:LaunchPresto}"; Flags: nowait postinstall skipifsilent
 
@@ -238,4 +240,46 @@ end;
 function ShouldDeleteUserPrestoData(): Boolean;
 begin
   Result := DeleteUserPrestoData;
+end;
+
+function NeedsVCRedist(): Boolean;
+var
+  Version: string;
+  MajorVersion: Cardinal;
+  MinorVersion: Cardinal;
+  BuildVersion: Cardinal;
+begin
+  // Check for Visual C++ 2015-2022 Redistributable (v14.0 or higher)
+  // The registry key is shared across VC++ 2015, 2017, 2019, and 2022
+
+  #if ARG_ARCH == "arm64"
+    // ARM64: Check ARM64 registry
+    if RegQueryStringValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\ARM64', 'Version', Version) then begin
+      if RegQueryDwordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\ARM64', 'Major', MajorVersion) and
+         RegQueryDwordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\ARM64', 'Minor', MinorVersion) and
+         RegQueryDwordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\ARM64', 'Bld', BuildVersion) then begin
+        // VC++ 2015-2022 is v14.x, we need at least v14.0
+        if (MajorVersion >= 14) then begin
+          Result := False;
+          Exit;
+        end;
+      end;
+    end;
+  #else
+    // x64: Check x64 registry
+    if RegQueryStringValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Version',Version) then begin
+      if RegQueryDwordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Major', MajorVersion) and
+         RegQueryDwordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Minor', MinorVersion) and
+         RegQueryDwordValue(HKLM64, 'SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\x64', 'Bld', BuildVersion) then begin
+        // VC++ 2015-2022 is v14.x, we need at least v14.0
+        if (MajorVersion >= 14) then begin
+          Result := False;
+          Exit;
+        end;
+      end;
+    end;
+  #endif
+
+  // Not found or version too old, needs installation
+  Result := True;
 end;

--- a/cmd/presto-desktop/build/index.html
+++ b/cmd/presto-desktop/build/index.html
@@ -10,28 +10,48 @@
 		<link rel="icon" href="/favicon-16x16.png" type="image/png" sizes="16x16" />
 		<link rel="apple-touch-icon" href="/apple-touch-icon.png" />
 		<link rel="manifest" href="/manifest.json" />
-		<link href="/_app/immutable/entry/start.DJZJZ-NY.js" rel="modulepreload">
-		<link href="/_app/immutable/chunks/C2FmCXqr.js" rel="modulepreload">
-		<link href="/_app/immutable/chunks/DYLzgBcJ.js" rel="modulepreload">
-		<link href="/_app/immutable/chunks/LYDb2PK_.js" rel="modulepreload">
-		<link href="/_app/immutable/entry/app.Cmq2LxCy.js" rel="modulepreload">
-		<link href="/_app/immutable/chunks/CA356dsv.js" rel="modulepreload">
-		<link href="/_app/immutable/chunks/AZeLEXKw.js" rel="modulepreload">
+		<link href="/_app/immutable/entry/start.DM5rE_RC.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/CMuo094s.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/B13LU96S.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/C472tP5V.js" rel="modulepreload">
+		<link href="/_app/immutable/entry/app.Brd1KsfM.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/DKwHt3Ho.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/ibwe1TAv.js" rel="modulepreload">
+		<link href="/_app/immutable/nodes/0.B3gBHq3O.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/B4VYX5P12.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/CKkYANg12.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/BTIx_iD02.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/DfTgOpck.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/sioIeFQP.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/D50ttkME.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/Bg0CL1t7.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/kE_2WStO.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/SOgC76mi.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/B81kRXWw.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/Bd1Ird9i2.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/ClJXqmxC2.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/CvwsdwXa2.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/DqhZwx5b2.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/DVOvLpzX2.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/Dj0T8tAy2.js" rel="modulepreload">
+		<link href="/_app/immutable/chunks/D1ViXCms2.js" rel="modulepreload">
 		
+		<link href="/_app/immutable/assets/0.Cfw-D1dj.css" rel="stylesheet">
+		<link href="/_app/immutable/assets/app.DuZVD5T5.css" rel="stylesheet">
 	</head>
 	<body data-sveltekit-preload-data="hover">
 		<div style="display: contents">
 			<script>
 				{
-					__sveltekit_1dsx2u2 = {
+					__sveltekit_1y99gz7 = {
 						base: ""
 					};
 
 					const element = document.currentScript.parentElement;
 
 					Promise.all([
-						import("/_app/immutable/entry/start.DJZJZ-NY.js"),
-						import("/_app/immutable/entry/app.Cmq2LxCy.js")
+						import("/_app/immutable/entry/start.DM5rE_RC.js"),
+						import("/_app/immutable/entry/app.Brd1KsfM.js")
 					]).then(([kit, app]) => {
 						kit.start(app, element);
 					});

--- a/cmd/presto-desktop/preview.go
+++ b/cmd/presto-desktop/preview.go
@@ -468,6 +468,7 @@ func (a *App) finishPreviewUpdate(result *preview.UpdateResult, typstSource stri
 				logger.Warn("[preview] tinymist refresh failed", "version", result.Version, "error", err)
 			}
 			_ = a.previewRunner.stop()
+			previousProcess = runningPreviewProcess{}
 			return applyFallback(fmt.Sprintf("tinymist preview refresh failed: %v", err))
 		}
 	}

--- a/cmd/presto-desktop/preview_test.go
+++ b/cmd/presto-desktop/preview_test.go
@@ -230,7 +230,7 @@ func TestPreviewRunnerStopsBrokenSessionAfterRefreshFailure(t *testing.T) {
 	compiler := typst.NewCompiler()
 	compiler.BinPath = filepath.Join(t.TempDir(), "missing-typst")
 	service := preview.NewService()
-	runner := newPreviewRunner(service, "tinymist")
+	runner := newPreviewRunner(service, filepath.Join(t.TempDir(), "tinymist"))
 	app := NewApp(
 		template.NewManager(templateRoot),
 		compiler,


### PR DESCRIPTION
- Add automated download scripts for Typst, TinyMist, and Inno Setup language files
- Change installer to user-level by default (no admin required)
- Use correct install paths based on privilege mode (Program Files vs AppData)
- Skip VC++ Redistributable installation if already present
- Fix PowerShell 7 usage for Get-FileHash in build scripts
- Update frontend build artifacts
- Fix preview runner refresh failure test